### PR TITLE
Add Robi Axiata trainee experience

### DIFF
--- a/js/work_experience.js
+++ b/js/work_experience.js
@@ -73,6 +73,18 @@
         ]
       },
       {
+        title: "Industrial Trainee",
+        company: "Robi Axiata Limited",
+        companyLink: "https://www.robi.com.bd/",
+        logo: "https://raw.githubusercontent.com/Nafiz43/portfolio/refs/heads/main/img/robi.png",
+        date: "December 2019 - January 2020",
+        width: 80,
+        height: 80,
+        tasks: [
+          "Developed optimized route plans for the <strong>Direct Sales Representative (DSR) Route Optimization</strong> project, enhancing DSRs' efficiency in servicing retail shops by analyzing walking patterns and incorporating real-world constraints."
+        ]
+      },
+      {
         title: "Software Engineer",
         company: "GuardForce Securities",
         logo: "img/guard_force.png",


### PR DESCRIPTION
## Summary
- insert Robi Axiata Limited industrial trainee role into work experience data before GuardForce experience
- use hosted Robi Axiata logo for Industrial Trainee entry

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b57dfa0d7c832aa2c93902ab16b6aa